### PR TITLE
Add support for breaking <svg> into templates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,12 @@ function parseHtmlStart(tag, tagName, attributes, selfClosing) {
     hooks = elementHooksFromAttributes(attributes);
   }
   var attributesMap = parseAttributes(attributes);
-  var namespaceUri = (lowerTagName === 'svg') ?
+  // Check if the element is part of <svg>. This is important because svg
+  // elements must be created differently - via document.createElementNS().
+  // Also treat all elements in a template as svg ones if template was
+  // defined with 'svg' attribute.
+  var namespaceUri = (lowerTagName === 'svg' ||
+    (parseNode.view && parseNode.view.options && parseNode.view.options.svg)) ?
     templates.NAMESPACE_URIS.svg : parseNode.namespaceUri;
   var Constructor = templates.Element;
   if (lowerTagName === 'tag') {


### PR DESCRIPTION
Add `svg` option into templates definition which instructs parser to treat all elements in this template as svg:

```html
<index:>
  <svg>
    <g>
      {{each @points as #point}}
        <view is='point' />
      {{/}}
    </g>
  </svg>

<point: svg>
  <g>
    <circle cx='{{ #point.x }}' cy='{{ #point.y }}' r='{{ #point.r }}' />
    <text x='{{ #point.x }}' y='{{ #point.y }}'>{{ #point.label }}</text>
  </g>

Currently if you try to break `<svg>` into templates it won't show elements from those templates at all because the information about them being part of `<svg>` is lost and it creates them via `document.createElement()` instead of `document.createElementNS()`.

So this pull request fixes it. Though I think it should be possible to get rid of the explicit `svg` in template declaration if we modify the `Element.prototype.appendTo()` to figure out on execution time whether the element has the `<svg>` ancestor or not.