### PR TITLE
Better errors for improper block expressions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -271,10 +271,17 @@ function parseBlockExpression(expression) {
     parseNode = parseNode.child();
 
     if (last instanceof templates.ConditionalBlock) {
+      if ((last.expressions[last.expressions.length - 1]).meta.blockType === 'else') {
+        throw new Error('Conflicting tag: {{' + last.beginning + '}} already has an {{else}}');
+      }
       last.expressions.push(expression);
       last.contents.push(parseNode.content);
     } else if (last instanceof templates.EachBlock) {
       if (blockType !== 'else') unexpected(expression.meta.source);
+      if (last.elseContent) {
+        console.log(last);
+        throw new Error('Conflicting tag: {{' + last.expression.meta.source + '}} already has an {{else}}');
+      }
       last.elseContent = parseNode.content;
     } else {
       unexpected(expression.meta.source);

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,14 +272,15 @@ function parseBlockExpression(expression) {
 
     if (last instanceof templates.ConditionalBlock) {
       if ((last.expressions[last.expressions.length - 1]).meta.blockType === 'else') {
-        throw new Error('Conflicting tag: {{' + last.beginning + '}} already has an {{else}}');
+        throw new Error('Conflicting tag: {{' + last.beginning + '}} already has an {{else}} ');
       }
       last.expressions.push(expression);
       last.contents.push(parseNode.content);
     } else if (last instanceof templates.EachBlock) {
-      if (blockType !== 'else') unexpected(expression.meta.source);
+      if (blockType !== 'else') {
+        throw new Error('Conflicting tag: {{' + expression.meta.source + '}} cannot be within {{' + last.expression.meta.source + '}}');
+      }
       if (last.elseContent) {
-        console.log(last);
         throw new Error('Conflicting tag: {{' + last.expression.meta.source + '}} already has an {{else}}');
       }
       last.elseContent = parseNode.content;

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,11 @@ function createTemplate(source, view) {
       } else {
         throw new Error('Missing closing HTML tag: ' + last.endTag);
       }
+    } else if ((last instanceof templates.Block)) {
+      var lastExpression = last.expression || last.expressions[0];
+      if (!lastExpression.meta.isEnd) {
+        throw new Error('Missing closing tag: {{' + last.beginning + '}}');
+      }
     }
     unexpected();
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,14 +152,17 @@ function parseAttributes(attributes) {
 function parseHtmlEnd(tag, tagName) {
   parseNode = parseNode.parent;
   var last = parseNode && parseNode.last();
-  if (last && (last instanceof templates.Block)) {
+  if (!last) {
+    throw new Error('Missing HTML tag: ' + tag + ' doesn\'t have an opening tag');
+  }
+  if ((last instanceof templates.Block)) {
     throw new Error('Missing closing tag: {{' + last.beginning + '}}');
   }
   if (!(
     (last instanceof templates.DynamicElement && tagName.toLowerCase() === 'tag') ||
     (last instanceof templates.Element && last.tagName === tagName)
   )) {
-    throw new Error('Mismatched closing HTML tag: ' + tag);
+    throw new Error('Mismatched HTML tags: ' + tag + ' doesn\'t close <' + last.tagName + '>');
   }
   parseElementClose(tagName);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,10 @@ function parseAttributes(attributes) {
 
 function parseHtmlEnd(tag, tagName) {
   parseNode = parseNode.parent;
-  var last = parseNode.last();
+  var last = parseNode && parseNode.last();
+  if (last && (last instanceof templates.Block)) {
+    throw new Error('Missing closing tag: {{' + last.beginning + '}}');
+  }
   if (!(
     (last instanceof templates.DynamicElement && tagName.toLowerCase() === 'tag') ||
     (last instanceof templates.Element && last.tagName === tagName)

--- a/lib/index.js
+++ b/lib/index.js
@@ -247,7 +247,7 @@ function parseBlockExpression(expression) {
       throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} has no opening tag');
     }
     if (!(last instanceof templates.Block)) {
-      throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} does not match opening <' + last.tagName + '>');
+      throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} does not match <' + last.tagName + '>');
     }
     var lastExpression = last.expression || (last.expressions && last.expressions[0]);
     if (!(
@@ -261,7 +261,13 @@ function parseBlockExpression(expression) {
   // Continuing block
   } else if (blockType === 'else' || blockType === 'else if') {
     parseNode = parseNode.parent;
-    var last = parseNode.last();
+    var last = parseNode && parseNode.last();
+    if (!last) {
+      throw new Error('Mismatched template tag: {{' + expression.meta.source + '}} has no opening tag');
+    }
+    if (!(last instanceof templates.Block)) {
+      throw new Error('Mismatched template tag: {{' + expression.meta.source + '}} does not match <' + last.tagName + '>');
+    }
     parseNode = parseNode.child();
 
     if (last instanceof templates.ConditionalBlock) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,14 +237,20 @@ function parseBlockExpression(expression) {
   if (expression.meta.isEnd) {
     parseNode = parseNode.parent;
     // Validate that the block ending matches an appropriate block start
-    var last = parseNode.last();
-    var lastExpression = last && (last.expression || (last.expressions && last.expressions[0]));
+    var last = parseNode && parseNode.last();
+    if (!last) {
+      throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} has no opening tag');
+    }
+    if (!(last instanceof templates.Block)) {
+      throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} does not match opening <' + last.tagName + '>');
+    }
+    var lastExpression = last.expression || (last.expressions && last.expressions[0]);
     if (!(
       lastExpression &&
       (blockType === 'end' && lastExpression.meta.blockType) ||
       (blockType === lastExpression.meta.blockType)
     )) {
-      throw new Error('Mismatched closing template tag: ' + expression.meta.source);
+      throw new Error('Mismatched closing template tag: {{' + expression.meta.source + '}} does not match {{' + last.beginning + '}}');
     }
 
   // Continuing block

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -60,19 +60,19 @@ describe('Parse and render literal HTML', function() {
   it('throws on no opening HTML tag', function() {
     expect(function() {
       parsing.createTemplate('</div>');
-    }).to.throwException(/Mismatched closing HTML tag: <\/div>/);
+    }).to.throwException(/Missing HTML tag: <\/div> doesn't have an opening tag/);
   });
 
   it('throws on a mismatched closing HTML tag', function() {
     expect(function() {
       parsing.createTemplate('<div><a></div>');
-    }).to.throwException(/Mismatched closing HTML tag: <\/div>/);
+    }).to.throwException(/Mismatched HTML tags: <\/div> doesn't close <a>/);
   });
 
   it('throws on a missing </span> tag', function() {
     expect(function() {
-      parsing.createTemplate('<span><span></span>');
-    }).to.throwException(/Missing closing HTML tag: <\/span>/);
+      parsing.createTemplate('<span><strong></span>');
+    }).to.throwException(/Mismatched HTML tags: <\/span> doesn't close <strong>/);
   });
 
   it('throws on a missing </div> tag', function() {

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -194,13 +194,25 @@ describe('Parse and render dynamic text and blocks', function() {
   it('throws on unclosed HTML tags in blocks', function() {
     expect(function() {
       parsing.createTemplate('{{if 1}}<div>{{/if}}');
-    }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} does not match opening <div>/);
+    }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} does not match <div>/);
   });
 
   it('throws on mismatched block tags', function() {
     expect(function() {
       parsing.createTemplate('{{if 1}}{{/each}}');
     }).to.throwException(/Mismatched closing template tag: \{\{\/each\}\} does not match \{\{if 1\}\}/);
+  });
+
+  it('throws on unmatched continuing block expressions', function() {
+    expect(function() {
+      parsing.createTemplate('{{else}}');
+    }).to.throwException(/Mismatched template tag: \{\{\else\}\} has no opening tag/);
+  });
+
+  it('throws on unmatched continuing block expressions in HTML tags', function() {
+    expect(function() {
+      parsing.createTemplate('<div>{{else}}</div>');
+    }).to.throwException(/Mismatched template tag: \{\{\else\}\} does not match <div>/);
   });
 });
 

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -185,6 +185,12 @@ describe('Parse and render dynamic text and blocks', function() {
     }).to.throwException(/Missing closing tag: \{\{if 1\}\}/);
   });
 
+  it('throws on unclosed block tags with a continuing expression', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}{{else}}');
+    }).to.throwException(/Missing closing tag: \{\{if 1\}\}/);
+  });
+
   it('throws on unopened block tags', function() {
     expect(function() {
       parsing.createTemplate('{{/if}}');
@@ -203,10 +209,28 @@ describe('Parse and render dynamic text and blocks', function() {
     }).to.throwException(/Mismatched closing template tag: \{\{\/each\}\} does not match \{\{if 1\}\}/);
   });
 
-  it('throws on unmatched continuing block expressions', function() {
+  it('throws on unmatched continuing expressions', function() {
     expect(function() {
       parsing.createTemplate('{{else}}');
     }).to.throwException(/Mismatched template tag: \{\{\else\}\} has no opening tag/);
+  });
+
+  it('throws on repeated {{else}} in {{if}}', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}{{else}}{{else}}{{/if}}');
+    }).to.throwException(/Conflicting tag: {{if 1}} already has an \{\{else}\}/);
+  });
+
+  it('throws on {{else if}} after {{else}}', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}{{else}}{{else if 2}}{{/if}}');
+    }).to.throwException(/Conflicting tag: {{if 1}} already has an \{\{else}\}/);
+  });
+
+  it('throws on repeated {{else}} in {{each}}', function() {
+    expect(function() {
+      parsing.createTemplate('{{each [1]}}{{else}}{{else}}{{/if}}');
+    }).to.throwException(/Conflicting tag: {{each \[1\]}} already has an \{\{else}\}/);
   });
 
   it('throws on unmatched continuing block expressions in HTML tags', function() {

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -57,6 +57,12 @@ describe('Parse and render literal HTML', function() {
     });
   }
 
+  it('throws on no opening HTML tag', function() {
+    expect(function() {
+      parsing.createTemplate('</div>');
+    }).to.throwException(/Mismatched closing HTML tag: <\/div>/);
+  });
+
   it('throws on a mismatched closing HTML tag', function() {
     expect(function() {
       parsing.createTemplate('<div><a></div>');
@@ -183,6 +189,12 @@ describe('Parse and render dynamic text and blocks', function() {
     expect(function() {
       parsing.createTemplate('{{if 1}}');
     }).to.throwException(/Missing closing tag: \{\{if 1\}\}/);
+  });
+
+  it('throws on unclosed block tags in HTML', function() {
+    expect(function() {
+      parsing.createTemplate('<div>{{if 1}}{{else}}</div>');
+    }).to.throwException(/Missing closing tag: \{\{\if 1\}\}/);
   });
 
   it('throws on unclosed block tags with a continuing expression', function() {

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -179,13 +179,19 @@ describe('Parse and render dynamic text and blocks', function() {
     test('{{each _page.letters as #letter, #i}}{{#i + 1}}:{{#letter}};{{/each}}', '1:A;2:B;3:C;');
   });
 
+  it('throws on unclosed block tags', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}');
+    }).to.throwException(/Missing closing tag: \{\{if 1\}\}/);
+  });
+
   it('throws on unopened block tags', function() {
     expect(function() {
       parsing.createTemplate('{{/if}}');
     }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} has no opening tag/);
   });
 
-  it('throws on unclosed HTML tags', function() {
+  it('throws on unclosed HTML tags in blocks', function() {
     expect(function() {
       parsing.createTemplate('{{if 1}}<div>{{/if}}');
     }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} does not match opening <div>/);

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -178,6 +178,24 @@ describe('Parse and render dynamic text and blocks', function() {
   it('index alias to each block', function() {
     test('{{each _page.letters as #letter, #i}}{{#i + 1}}:{{#letter}};{{/each}}', '1:A;2:B;3:C;');
   });
+
+  it('throws on unopened block tags', function() {
+    expect(function() {
+      parsing.createTemplate('{{/if}}');
+    }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} has no opening tag/);
+  });
+
+  it('throws on unclosed HTML tags', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}<div>{{/if}}');
+    }).to.throwException(/Mismatched closing template tag: \{\{\/if\}\} does not match opening <div>/);
+  });
+
+  it('throws on mismatched block tags', function() {
+    expect(function() {
+      parsing.createTemplate('{{if 1}}{{/each}}');
+    }).to.throwException(/Mismatched closing template tag: \{\{\/each\}\} does not match \{\{if 1\}\}/);
+  });
 });
 
 describe('Parse and render HTML and blocks', function() {

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -205,8 +205,8 @@ describe('Parse and render dynamic text and blocks', function() {
 
   it('throws on mismatched block tags', function() {
     expect(function() {
-      parsing.createTemplate('{{if 1}}{{/each}}');
-    }).to.throwException(/Mismatched closing template tag: \{\{\/each\}\} does not match \{\{if 1\}\}/);
+      parsing.createTemplate('{{if 1}}{{/unless}}');
+    }).to.throwException(/Mismatched closing template tag: \{\{\/unless\}\} does not match \{\{if 1\}\}/);
   });
 
   it('throws on unmatched continuing expressions', function() {
@@ -225,6 +225,12 @@ describe('Parse and render dynamic text and blocks', function() {
     expect(function() {
       parsing.createTemplate('{{if 1}}{{else}}{{else if 2}}{{/if}}');
     }).to.throwException(/Conflicting tag: {{if 1}} already has an \{\{else}\}/);
+  });
+
+  it('throws on {{else if}} in {{each}}', function() {
+    expect(function() {
+      parsing.createTemplate('{{each [1]}}{{else if 1}}{{/each}}');
+    }).to.throwException(/Conflicting tag: \{\{else if 1\}\} cannot be within \{\{each \[1\]}\}/);
   });
 
   it('throws on repeated {{else}} in {{each}}', function() {


### PR DESCRIPTION
New checks:
- Unclosed block expressions like `{{if 1}} {{else if 2}}` (no `{{/if}}`)
- Multiple `{{else}}` in `{{if}}{{/if}}` or `{{each}}{{/each}}`

**This is breaking.** Templates which had unclosed or improperly formed conditional blocks will no longer compile...although they were probably broken already :whale: 
