### PR TITLE
Support a().b(), $at(_path).fn(), new a().b() in expressions

### DIFF
--- a/lib/createPathExpression.js
+++ b/lib/createPathExpression.js
@@ -132,15 +132,24 @@ function reduceFnExpression(node, afterSegments, Constructor) {
   var callee = node.callee;
   if (callee.type === Syntax.Identifier) {
     if (callee.name === '$at') {
-      return new expressions.ScopedModelExpression(args[0]);
+      return new expressions.ScopedModelExpression(args[0], afterSegments);
     }
     var segments = [callee.name];
-    return new Constructor(segments, args, afterSegments);
-  } else if (callee.type === Syntax.MemberExpression) {
-    var segments = reduceMemberExpression(callee).segments;
-    return new Constructor(segments, args, afterSegments);
+    return new Constructor(null, segments, args, afterSegments);
   } else {
-    unexpected(node);
+    var expression = reduce(callee);
+    if (expression.type === 'PathExpression') {
+      var segments = expression.segments;
+      return new Constructor(null, segments, args, afterSegments);
+    } else {
+      if (expression.afterSegments) {
+        var segments = expression.afterSegments;
+        expression.afterSegments = [];
+        return new Constructor(expression, segments, args, afterSegments);
+      } else {
+        return new Constructor(expression, [], args, afterSegments);
+      }
+    }
   }
 }
 

--- a/test/expressions.mocha.js
+++ b/test/expressions.mocha.js
@@ -278,15 +278,15 @@ describe('Expression::get', function() {
     var expression = create('(_page.date).valueOf()');
     expect(expression.get(context)).to.equal(1000);
   });
-  it.skip('gets method call of the result of an fn expressions', function() {
+  it('gets method call of the result of an fn expressions', function() {
     var expression = create('passThrough(_page.date).valueOf()');
     expect(expression.get(context)).to.equal(1000);
   });
-  it.skip('gets method call of the result of a `new` expressions', function() {
+  it('gets method call of the result of a `new` expressions', function() {
     var expression = create('new Date(1000).valueOf()');
     expect(expression.get(context)).to.equal(1000);
   });
-  it.skip('gets method call of a scoped model expression', function() {
+  it('gets method call of a scoped model expression', function() {
     var expression = create('$at(_page.nums[3]).path()');
     expect(expression.get(context)).to.equal('_page.nums.3');
   });


### PR DESCRIPTION
The PR fix some lacks in derby-parser and derby-templates. 

After the commit the derby-parsing tests passed correctly:

```
  it('gets method call of the result of an fn expressions', function() {
    var expression = create('passThrough(_page.date).valueOf()');
    expect(expression.get(context)).to.equal(1000);
  });
  it('gets method call of the result of a `new` expressions', function() {
    var expression = create('new Date(1000).valueOf()');
    expect(expression.get(context)).to.equal(1000);
  });
  it('gets method call of a scoped model expression', function() {
    var expression = create('$at(_page.nums[3]).path()');
    expect(expression.get(context)).to.equal('_page.nums.3');
  });
```

Here is the corresponding derby-templates PR - https://github.com/derbyjs/derby-templates/pull/15

P.S. for sure it doesn't break anything. All the tests passed.
