### PR TITLE
Support "within" attribute for view array tags, add tests for "within"…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -508,17 +508,20 @@ function parseNameAttribute(element) {
 
 function parseAttributeElement(element, name, viewAttributes) {
   var camelName = dashToCamelCase(name);
-  var content = new templates.Template(element.content);
+  var contentTemplate = new templates.Template(element.content);
   viewAttributes[camelName] = (element.attributes && element.attributes.within) ?
-    content : new templates.ParentWrapper(content);
+    contentTemplate : new templates.ParentWrapper(contentTemplate);
 }
 
 function parseArrayElement(element, name, viewAttributes) {
   var item = viewAttributesFromElement(element);
   if (!item.hasOwnProperty('content') && element.content.length) {
-    item.content = new templates.ParentWrapper(
-      new templates.Template(element.content)
-    );
+    var contentTemplate = new templates.Template(element.content);
+    if (element.attributes && element.attributes.within) {
+      item.content = contentTemplate;
+    } else {
+      item.content = new templates.ParentWrapper(contentTemplate);
+    }
   }
   var camelName = dashToCamelCase(name);
   var viewAttribute = viewAttributes[camelName] ||

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -522,4 +522,54 @@ describe('View insertion', function() {
     );
   });
 
+  it('view usage supports "within" attribute on child tags to use context from inside view', function() {
+    var views = new templates.Views();
+    context.meta.views = views;
+    views.register('body'
+    , '<view is="custom-list" items="{{[\'item A\', \'item B\']}}">' +
+        '<item-content within><b>{{#item}}</b></item-content>' +
+      '</view>'
+    );
+    views.register('custom-list'
+    , '<ul>' +
+        '{{each @items as #item}}' +
+          '<li>{{@itemContent}}</li>' +
+        '{{/each}}' +
+      '</ul>'
+    , {attributes: 'item-content'}
+    );
+    var view = views.find('body');
+    expect(view.get(context)).equal('<ul><li><b>item A</b></li><li><b>item B</b></li></ul>');
+  });
+
+  it('view usage supports "within" attribute on child array tags to use context from inside view', function() {
+    var views = new templates.Views();
+    context.meta.views = views;
+    views.register('body'
+    , '<view is="custom-table" items="{{[\'item A\', \'item BB\']}}">' +
+        '<row-cell within>Text: {{#item}}</row-cell>' +
+        '<row-cell within>Length: {{#item.length}}</row-cell>' +
+      '</view>'
+    );
+    views.register('custom-table'
+    , '<table>' +
+        '{{each @items as #item}}' +
+          '<tr>' +
+            '{{each @rowCells as #rowCell}}' +
+              '<td>{{#rowCell.content}}</td>' +
+            '{{/each}}' +
+          '</tr>' +
+        '{{/each}}' +
+      '</table>'
+    , {arrays: 'row-cell/rowCells'}
+    );
+    var view = views.find('body');
+    expect(view.get(context)).equal(
+      '<table>' +
+        '<tr><td>Text: item A</td><td>Length: 6</td></tr>' +
+        '<tr><td>Text: item BB</td><td>Length: 7</td></tr>' +
+      '</table>'
+    );
+  });
+
 });


### PR DESCRIPTION
… attribute for both attribute tags and array tags

From a usage perspective, array tags in view content are basically attribute tags except that there's more than one of a particular tag name. However, the `within` attribute didn't work on array tags to have them use the "inside context", the context of the view declaration.

This adds support for the `within` attribute on array tags, and it adds tests for `within` for both the existing attribute-tag case and for the new array-tag case.

Example:
```
<page:>
  <view is="custom-table" items="{{['item A', 'item BB']}}">
    <row-cell within>Text: {{#item}}</row-cell>
    <row-cell within>Length: {{#item.length}}</row-cell>
  </view>

<custom-table: arrays="row-cell/rowCells">
  <table>
    {{each @items as #item}}
      <tr>
        {{each @rowCells as #rowCell}}
          <td>{{#rowCell.content}}</td>
        {{/each}}
      </tr>
    {{/each}}
  </table>
```