### PR TITLE
Validate alias declarations in {{with}} and {{each}} blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
-Work in progress...
-
-derby-html-parser
+derby-parsing
 ===============
 
-Add HTML-based template parsing to Derby
+This module contains the HTML-based template parsing for [DerbyJS](https://github.com/derbyjs/derby). Given a template source string, it produces parsed `Template`s and `Expression`s as defined in [derbyjs/derby-templates](https://github.com/derbyjs/derby-templates).
+
+## Installation
+
+```shell
+npm install derby-parsing
+```
+
+## Example usage
+
+```javascript
+var derbyParsing = require('derby-parsing');
+
+var templateSource = '<title>{{_page.title}}</title>';
+var template = derbyParsing.createTemplate(templateSource);
+```
+
+## Tests
+
+```shell
+npm test
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -798,6 +798,12 @@ function createExpression(source) {
     expression = (path) ?
       createPathExpression(path) :
       new expressions.Expression();
+    if (meta.as) {
+      validateAlias(meta.as);
+    }
+    if (meta.keyAs) {
+      validateAlias(meta.keyAs);
+    }
   } catch (err) {
     var message = '\n\nWithin expression: ' + source;
     throw appendErrorMessage(err, message);
@@ -816,4 +822,18 @@ function appendErrorMessage(err, message) {
     return err;
   }
   return new Error(err + message);
+}
+
+function validateAlias(aliasStr) {
+  // Try parsing into a path expression. This throws on invalid expressions.
+  var expression = createPathExpression(aliasStr);
+  // Verify that it's an AliasPathExpression with no segments, i.e. that
+  // it has the format "#IDENTIFIER".
+  if (expression instanceof expressions.AliasPathExpression) {
+    if (expression.segments.length !== 0) {
+      throw new Error('Alias must not have dots or brackets: ' + aliasStr);
+    }
+  } else {
+    throw new Error('Alias must be an identifier starting with "#": ' + aliasStr);
+  }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -799,10 +799,10 @@ function createExpression(source) {
       createPathExpression(path) :
       new expressions.Expression();
     if (meta.as) {
-      validateAlias(meta.as);
+      meta.as = normalizeAlias(meta.as);
     }
     if (meta.keyAs) {
-      validateAlias(meta.keyAs);
+      meta.keyAs = normalizeAlias(meta.keyAs);
     }
   } catch (err) {
     var message = '\n\nWithin expression: ' + source;
@@ -824,7 +824,7 @@ function appendErrorMessage(err, message) {
   return new Error(err + message);
 }
 
-function validateAlias(aliasStr) {
+function normalizeAlias(aliasStr) {
   // Try parsing into a path expression. This throws on invalid expressions.
   var expression = createPathExpression(aliasStr);
   // Verify that it's an AliasPathExpression with no segments, i.e. that
@@ -832,6 +832,8 @@ function validateAlias(aliasStr) {
   if (expression instanceof expressions.AliasPathExpression) {
     if (expression.segments.length !== 0) {
       throw new Error('Alias must not have dots or brackets: ' + aliasStr);
+    } else {
+      return expression.alias;
     }
   } else {
     throw new Error('Alias must be an identifier starting with "#": ' + aliasStr);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
 --reporter spec
---bail

--- a/test/templates.mocha.js
+++ b/test/templates.mocha.js
@@ -99,6 +99,41 @@ describe('Parse and render dynamic text and blocks', function() {
     test('{{with _page.nope}}{{this}}{{/with}}', 'false');
   });
 
+  it('with block, valid alias', function() {
+    test('{{with _page.greeting as #greeting}}{{#greeting}}{{/with}}', 'Howdy!');
+  });
+
+  describe('with block, invalid alias throws during parsing', function() {
+    it('no pound sign at start of alias', function() {
+      var source = '{{with _page.greeting as greeting}}{{/with}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+        console.log(template.content[0]);
+      }).to.throwException(/Alias must be an identifier starting with "#"/);
+    });
+
+    it('trailing parenthesis in alias', function() {
+      var source = '{{with _page.greeting as #greeting)}}{{/with}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Unexpected token \)/);
+    });
+
+    it('brackets in alias', function() {
+      var source = '{{with _page.greeting as #greeting[0]}}{{/with}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
+
+    it('dots in alias', function() {
+      var source = '{{with _page.greeting as #greeting.a}}{{/with}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
+  });
+
   it('if block', function() {
     test('{{if _page.yep}}yes{{/if}}', 'yes');
     test('{{if _page.yep}}{{this}}{{/if}}', 'true');
@@ -177,6 +212,64 @@ describe('Parse and render dynamic text and blocks', function() {
 
   it('index alias to each block', function() {
     test('{{each _page.letters as #letter, #i}}{{#i + 1}}:{{#letter}};{{/each}}', '1:A;2:B;3:C;');
+  });
+
+  describe('each block, invalid alias throws during parsing', function() {
+    it('no pound sign at start of alias', function() {
+      var source = '{{each _page.letters as letter}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must be an identifier starting with "#"/);
+    });
+
+    it('trailing parenthesis in alias', function() {
+      var source = '{{each _page.letters as #letter)}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Unexpected token \)/);
+    });
+
+    it('brackets in alias', function() {
+      var source = '{{each _page.letters as #letter[0]}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
+
+    it('dots in alias', function() {
+      var source = '{{each _page.letters as #letter.a}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
+
+    it('no pound sign at start of index alias', function() {
+      var source = '{{each _page.letters as #letter, index}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must be an identifier starting with "#"/);
+    });
+
+    it('trailing parenthesis in index alias', function() {
+      var source = '{{each _page.letters as #letter, #index)}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Unexpected token \)/);
+    });
+
+    it('brackets in index alias', function() {
+      var source = '{{each _page.letters as #letter, #index[0]}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
+
+    it('dots in index alias', function() {
+      var source = '{{each _page.letters as #letter, #index.a}}{{/each}}';
+      expect(function() {
+        var template = parsing.createTemplate(source);
+      }).to.throwException(/Alias must not have dots or brackets/);
+    });
   });
 });
 


### PR DESCRIPTION
## The issue

As reported in https://github.com/derbyjs/derby-parsing/issues/16, Derby currently will parse these blocks without complaint:

```
{{each items as item}}
  <li>{{item}}</li>
{{/each}}
{{each items as #item)}}
  <li>{{#item}}</li>
{{/each}}
```

In the first case, the alias is set to `item`, and in the second, the alias is set to `#item)`. This is because extracting the aliases is done with a relatively loose regular expression. However, it's impossible to actually use these aliases:

* You can't use the `item` alias because Derby uses the `#` prefix as a signal to check block aliases. Without the `#` prefix, Derby will instead attempt to look for `item` on the model, without checking aliases as it's going up the context tree.
* You can't use the `#item)` alias because esprima-derby won't parse the random closing paren as part of the identifier.

## Changes

* Validate the aliases `as` (e.g. `#item`) and `keyAs` (e.g. `#itemIndex`) that are extracted by the regular expression, by running the alias strings through `createPathExpression`:
  * `createPathExpression` will throw if the alias isn't a valid expression, which covers the `#item)` case.
  * Verify the returned expression is an `AliasPathExpression` with `segments.length === 0`. This covers the `item` case, which parses into a `PathExpression` and not an `AliasPathExpression`, as well as the `item.foo` case, which has `segments.length = 1`. The latter case is fine when using the alias, but not when defining it.
* Add tests for with/each block aliases.
* Add some content to the README.

Note that the first change will cause new parse errors to be thrown. @nateps and I feel this is OK, since the cases where the new parse errors are thrown would have been obvious-looking run-time bugs before.