### PR TITLE
Fix leaks: Use updated derby-templates module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -457,7 +457,7 @@ function componentHooksFromAttributes(attributes) {
     // Parse `as` assignments
     if (key === 'as') {
       var segments = parseAsAttribute(key, value);
-      hooks.push(new templates.AsProperty(segments));
+      hooks.push(new templates.AsPropertyComponent(segments));
       delete attributes[key];
       continue;
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/derbyjs/derby-parsing/issues"
   },
   "dependencies": {
-    "derby-templates": "^0.7.3",
+    "derby-templates": "^0.8.0",
     "esprima-derby": "^0.1.0",
     "html-util": "^0.2.0"
   },


### PR DESCRIPTION
Switch to templates.AsPropertyComponent where needed now that it has been separated from templates.AsProperty